### PR TITLE
fix: return `200` when request `options`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -703,7 +703,7 @@ async function dispatch_handler(request: Request, bucket: R2Bucket): Promise<Res
 	switch (request.method) {
 		case 'OPTIONS': {
 			return new Response(null, {
-				status: 204,
+				status: 200,
 				headers: {
 					Allow: SUPPORT_METHODS.join(', '),
 					DAV: DAV_CLASS,


### PR DESCRIPTION
`OPTIONS` return 200 or 204 should both be fine[^1][^2], but some clients using this to check authorization, don't care about protocol[^3] (#3 may be the same problem)


[^1]: https://stackoverflow.com/questions/14702962/can-an-http-options-request-return-a-204-or-should-it-always-return-200
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS#:~:text=Note%3A%20Both%20200%20OK%20and%20204%20No%20Content%20are%20permitted%20status%20codes%2C%20but%20some%20browsers%20incorrectly%20believe%20204%20No%20Content%20applies%20to%20the%20resource%20and%20do%20not%20send%20a%20subsequent%20request%20to%20fetch%20it.
[^3]: https://github.com/flymzero/webdav_client