### PR TITLE
fix: update wrangler.toml to use nodejs_compat

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@ compatibility_date = "2023-10-16"
 main = "src/index.ts"
 name = "r2-webdav"
 
-node_compat = true
+compatibility_flags = ["nodejs_compat"]
 
 # Bind an R2 Bucket. Use R2 to store arbitrarily large blobs of data, such as files.
 # Docs: https://developers.cloudflare.com/r2/api/workers/workers-api-usage/


### PR DESCRIPTION
### Problem

Running `wrangler dev` throws the following errors:

####  Error
```
✘ [ERROR] Processing wrangler.toml configuration:

    - Removed: "node_compat":
      The "node_compat" field is no longer supported as of Wrangler v4. Instead,
      use the `nodejs_compat` compatibility flag. This includes the functionality
      from legacy `node_compat` polyfills and natively implemented Node.js APIs. See
      https://developers.cloudflare.com/workers/runtime-apis/nodejs for more
      information.
```

### Solution

Update wrangler.toml to replace node_compat with compatibility_flags = ["nodejs_compat"].
```toml
compatibility_flags = ["nodejs_compat"]
```