### PR TITLE
fix: check suffix value in object range

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ function calcContentRange(object: R2ObjectBody) {
 	let rangeOffset = 0;
 	let rangeEnd = object.size - 1;
 	if (object.range) {
-		if ('suffix' in object.range) {
+		if (object.range.suffix != null) {
 			// Case 3: {suffix: number}
 			rangeOffset = object.size - object.range.suffix;
 		} else {


### PR DESCRIPTION
`'suffix' in object.range` gives true even if `suffix` is null, results in unexpected HTTP 206.

Should resolve #4.