### PR TITLE
fix: return 200 instead of 206 for non-Range GET requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -762,7 +762,7 @@ async function handle_get(request: Request, bucket: R2Bucket): Promise<Response>
 		} else {
 			const { rangeOffset, rangeEnd } = calcContentRange(object);
 			const contentLength = rangeEnd - rangeOffset + 1;
-			const rangeRequested = object.range !== undefined;
+			const rangeRequested = request.headers.has('Range') && object.range !== undefined;
 			return new Response(object.body, {
 				status: rangeRequested ? 206 : 200,
 				headers: {


### PR DESCRIPTION
Hello, I have noticed that while using Zotero, it frequently flags HTTP 206 as an unexpected response, which often results in file uploads failing.

When Zotero makes a regular GET request (without a `Range` header), R2 may still return a 206 Partial Content status in some edge cases. Zotero does not expect 206 for non-ranged requests and treats it as an error, causing WebDAV verification and sync to fail.

This PR checks the original request headers: if the client did not send a `Range` header, the response status is forced to 200 regardless of what R2 returns. This is more spec-compliant than checking `obj.range`, which can be populated even without a client-side Range request due to R2's internal behavior.